### PR TITLE
Remove virtualenv activation from wsgi file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ x.x.x
 
 * Added Python 3.7 support (already worked, but added to docs and tests).
 * Fixed expected response code in redirect test.
+* Removed virtualenv activation from aubrey-transcription.wsgi (better to do that from the server config)
 
 
 1.0.0

--- a/aubrey_transcription.wsgi
+++ b/aubrey_transcription.wsgi
@@ -8,10 +8,6 @@ ENV = os.path.join(BASE_DIR, 'env')
 # This app may not be installed, so add the project path to the system path.
 sys.path.insert(0, BASE_DIR)
 
-# Activate the virtual environment.
-activate_this = os.path.join(ENV, 'bin/activate_this.py')
-execfile(activate_this, dict(__file__=activate_this))
-
 # Initialize the app.
 from aubrey_transcription import create_app
 application = create_app()


### PR DESCRIPTION
It's better to handle this activation from the server's config files. Also, the current way isn't compatible with Python 3, and it uses the deprecated execfile. The code base is fine on 3+, it's just the wsgi file isn't tested in any way, which is yet another reason to leave as much out of there as possible.