### PR TITLE
Adjust the order of the items in the returned JSON.

### DIFF
--- a/aubrey_transcription/default_settings.py
+++ b/aubrey_transcription/default_settings.py
@@ -9,3 +9,4 @@ EXTENSIONS_META = {
 }
 FILENAME_PATTERN = (r'(?P<metaid>[^_]*)_m?(?P<manifestation>[^_]*)_(?P<fileset>[^-]*)'
                     r'-(?P<kind>[^-]*)-(?P<language>[^.]*)\.(?P<extension>.*)')
+JSON_SORT_KEYS = False

--- a/aubrey_transcription/utils.py
+++ b/aubrey_transcription/utils.py
@@ -87,7 +87,8 @@ def get_files_info(pairpath, files):
             }
             files_info[filename_dict['manifestation']][filename_dict['fileset']].append(file_info)
     if files_info:
-        files_info[filename_dict['manifestation']][filename_dict['fileset']].sort(key=assign_val_for_sorting)
+        files_info[filename_dict['manifestation']][filename_dict['fileset']].sort(
+            key=assign_val_for_sorting)
 
     return files_info
 

--- a/aubrey_transcription/utils.py
+++ b/aubrey_transcription/utils.py
@@ -20,7 +20,39 @@ def find_files(pairpath):
     normalized_path = os.path.normpath(full_path)
     if not os.path.isdir(normalized_path):
         return []
-    return os.listdir(normalized_path)
+    files = os.listdir(normalized_path)
+    try:
+        # Sort the files numerically by the fileset number
+        return sorted(files, key=lambda f: int(f.split('-')[0].split('_')[-1]))
+    except ValueError:
+        return files
+
+
+def assign_val_for_sorting(file_info):
+    """Turn the caption type and language into a single string that can be sorted.
+
+    We want the transcriptions to sort primarily by type in the following order:
+    captions -> subtitles -> chapters -> descriptions -> metadata -> thumbnails -> everything else
+    and then we want to secondarily sort alphabetically by language, but putting English first.
+    """
+    transcription_types = [
+        'captions',
+        'subtitles',
+        'chapters',
+        'descriptions',
+        'metadata',
+        'thumbnails',
+        'other'
+    ]
+    transcription_type = file_info.get('vtt_kind', 'other')
+    # First letter of the sort word is based on the transcription type
+    sort_word = chr(ord('a') + transcription_types.index(transcription_type))
+    # Last 3 letters are from the language, using 'aaa' for English so it sorts first
+    language = file_info.get('language', 'zzz')
+    if language == 'eng':
+        language = 'aaa'
+    sort_word += language
+    return sort_word
 
 
 def get_files_info(pairpath, files):
@@ -54,6 +86,8 @@ def get_files_info(pairpath, files):
                 'language': filename_dict['language'],
             }
             files_info[filename_dict['manifestation']][filename_dict['fileset']].append(file_info)
+    if files_info:
+        files_info[filename_dict['manifestation']][filename_dict['fileset']].sort(key=assign_val_for_sorting)
 
     return files_info
 

--- a/aubrey_transcription/utils.py
+++ b/aubrey_transcription/utils.py
@@ -23,8 +23,8 @@ def find_files(pairpath):
     files = os.listdir(normalized_path)
     try:
         # Sort the files numerically by the fileset number
-        return sorted(files, key=lambda f: int(f.split('-')[0].split('_')[-1]))
-    except ValueError:
+        return sorted(files, key=lambda f: int(decrypt_filename(f)['fileset']))
+    except (ValueError, KeyError):
         return files
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,8 @@ import re
 import pytest
 import mock
 
-from aubrey_transcription.utils import make_path, find_files, get_files_info, decrypt_filename
+from aubrey_transcription.utils import (make_path, find_files, get_files_info, decrypt_filename,
+    assign_val_for_sorting)
 
 
 FILENAME_REGEX = re.compile(r'(?P<metaid>[^_]*)_(?P<manifestation>[^_]*)_(?P<fileset>[^-]*)'
@@ -25,17 +26,35 @@ class TestMakePath():
 @mock.patch('aubrey_transcription.utils.os.path.isdir')
 @mock.patch('aubrey_transcription.utils.current_app', config={'PAIRTREE_BASE': '/right/here'})
 class TestFindFiles():
-    @pytest.mark.parametrize('expected', [
-        ['one.vtt'],
-        ['one.vtt', 'two.xml', 'three.jpg'],
-        [],
+    @pytest.mark.parametrize('dir_contents, expected', [
+        (
+            ['metadc977400_m1_2-subtitles-eng.vtt', 'metadc977400_m1_1-subtitles-fre.vtt'],
+            ['metadc977400_m1_1-subtitles-fre.vtt', 'metadc977400_m1_2-subtitles-eng.vtt']
+        ),
+        (['metadc977400_m1_1-subtitles-fre.vtt'], ['metadc977400_m1_1-subtitles-fre.vtt']),
+        ([],[]),
     ])
+    @mock.patch('aubrey_transcription.utils.sorted')
     @mock.patch('aubrey_transcription.utils.os.listdir')
-    def test_path_is_dir(self, mock_listdir, mock_current_app, mock_isdir, expected):
+    def test_path_is_dir(self, mock_listdir, mock_sorted, mock_current_app, mock_isdir, dir_contents, expected):
         pairpath = '/so/me/pa/th/somepath'
         mock_isdir.return_value = True
-        mock_listdir.return_value = expected
+        mock_listdir.return_value = dir_contents
+        mock_sorted.return_value = expected
         result = find_files(pairpath)
+        assert result == expected
+        mock_sorted.assert_called_once()
+
+    @mock.patch('aubrey_transcription.utils.sorted')
+    @mock.patch('aubrey_transcription.utils.os.listdir')
+    def test_non_int_filename(self, mock_listdir, mock_sorted, mock_current_app, mock_isdir):
+        pairpath = '/so/me/pa/th/somepath'
+        mock_isdir.return_value = True
+        expected = ['one.vtt', 'two.xml', 'three.jpg']
+        mock_listdir.return_value = expected
+        mock_sorted.side_effect = ValueError
+        result = find_files(pairpath)
+        # When the sorting fails, we expect to get the files in the order listdir gave them
         assert result == expected
 
     def test_path_is_not_dir(self, mock_current_app, mock_isdir):
@@ -52,6 +71,24 @@ class TestFindFiles():
         assert mock_isdir.call_args[0][0].endswith(expected)
 
 
+class TestAssignValForSorting():
+    @pytest.mark.parametrize('item, expected_value', [
+        # Captions should show up first so it gets the 'a' prefix
+        ({'vtt_kind': 'captions', 'language': 'fre'}, 'afre'),
+        # English should sort before other languages, so replace with 'aaa'
+        ({'vtt_kind': 'thumbnails', 'language': 'eng'}, 'faaa'),
+        ({'vtt_kind': 'chapters', 'language': 'ger'}, 'cger'),
+        # Missing or unknown vtt kinds sort last
+        ({'language': 'spa'}, 'gspa'),
+        # Missing languages sort last
+        ({'vtt_kind': 'metadata'}, 'ezzz'),
+        ({}, 'gzzz'),
+    ])
+    def test_assigns_expected_values(self, item, expected_value):
+        actual_value = assign_val_for_sorting(item)
+        assert actual_value == expected_value
+
+
 @mock.patch('aubrey_transcription.utils.decrypt_filename')
 @mock.patch('aubrey_transcription.utils.current_app', config={
     'EXTENSIONS_META': {'vtt': {'mimetype': 'text/vtt', 'use': 'vtt'}},
@@ -59,8 +96,10 @@ class TestFindFiles():
     'TRANSCRIPTION_URL': 'http://example.com',
 })
 class TestGetFilesInfo():
+    @mock.patch('aubrey_transcription.utils.assign_val_for_sorting')
     @mock.patch('aubrey_transcription.utils.os.path.getsize')
-    def test_returns_correct_info(self, mock_getsize, mock_current_app, mock_decrypt_filename):
+    def test_returns_correct_info(self, mock_getsize, mock_assign_val_for_sorting,
+            mock_current_app, mock_decrypt_filename):
         pairpath = '/pa/th/path'
         files = ['metaid_m1_1-captions-eng.vtt']
         mock_decrypt_filename.return_value = {
@@ -86,6 +125,7 @@ class TestGetFilesInfo():
         }
         result = get_files_info(pairpath, files)
         assert result == expected
+        mock_assign_val_for_sorting.assert_called_once_with(expected['1']['1'][0])
 
     @pytest.mark.parametrize('transcription_url', [
         'http://example.com',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 import mock
 
 from aubrey_transcription.utils import (make_path, find_files, get_files_info, decrypt_filename,
-    assign_val_for_sorting)
+                                        assign_val_for_sorting)
 
 
 FILENAME_REGEX = re.compile(r'(?P<metaid>[^_]*)_(?P<manifestation>[^_]*)_(?P<fileset>[^-]*)'
@@ -24,7 +24,8 @@ class TestMakePath():
 
 
 @mock.patch('aubrey_transcription.utils.os.path.isdir')
-@mock.patch('aubrey_transcription.utils.current_app', config={'PAIRTREE_BASE': '/right/here'})
+@mock.patch('aubrey_transcription.utils.current_app', config={
+    'PAIRTREE_BASE': '/right/here', 'FILENAME_REGEX': FILENAME_REGEX})
 class TestFindFiles():
     @pytest.mark.parametrize('dir_contents, expected', [
         (
@@ -32,18 +33,16 @@ class TestFindFiles():
             ['metadc977400_m1_1-subtitles-fre.vtt', 'metadc977400_m1_2-subtitles-eng.vtt']
         ),
         (['metadc977400_m1_1-subtitles-fre.vtt'], ['metadc977400_m1_1-subtitles-fre.vtt']),
-        ([],[]),
+        ([], []),
     ])
-    @mock.patch('aubrey_transcription.utils.sorted')
     @mock.patch('aubrey_transcription.utils.os.listdir')
-    def test_path_is_dir(self, mock_listdir, mock_sorted, mock_current_app, mock_isdir, dir_contents, expected):
+    def test_path_is_dir(self, mock_listdir, mock_current_app, mock_isdir,
+                         dir_contents, expected):
         pairpath = '/so/me/pa/th/somepath'
         mock_isdir.return_value = True
         mock_listdir.return_value = dir_contents
-        mock_sorted.return_value = expected
         result = find_files(pairpath)
         assert result == expected
-        mock_sorted.assert_called_once()
 
     @mock.patch('aubrey_transcription.utils.sorted')
     @mock.patch('aubrey_transcription.utils.os.listdir')
@@ -99,7 +98,7 @@ class TestGetFilesInfo():
     @mock.patch('aubrey_transcription.utils.assign_val_for_sorting')
     @mock.patch('aubrey_transcription.utils.os.path.getsize')
     def test_returns_correct_info(self, mock_getsize, mock_assign_val_for_sorting,
-            mock_current_app, mock_decrypt_filename):
+                                  mock_current_app, mock_decrypt_filename):
         pairpath = '/pa/th/path'
         files = ['metaid_m1_1-captions-eng.vtt']
         mock_decrypt_filename.return_value = {


### PR DESCRIPTION
ping @ldko @gracieflores, this is ready for review. The changes here are to sort the items returned in the JSON as defined in the issue. We first sort by transcription type, and then alphabetically by language, with English first.